### PR TITLE
Script to generate a trace from artifact files

### DIFF
--- a/ocp/analysisFuncs
+++ b/ocp/analysisFuncs
@@ -1,0 +1,411 @@
+#!/bin/bash
+# set -x
+# analysis functions 
+# can be used for both ci and clusters
+
+
+# debugbootstrap
+releaseImage () {
+echo "===================================================="
+echo "Check bootstrap/journals/release-image.log"
+if [[ ! -f  ${logb}/bootstrap/journals/release-image.log ]] ; then
+  echo "bootstrap/journals/release-image.log file not found"
+  return
+fi
+
+manifest=$(grep "Error reading manifest" ${logb}/bootstrap/journals/release-image.log | wc -l) 
+if [[ ${manifest} -ne 0 ]] ; then
+  echo "----------------------------------------------"
+  echo "    Error reading manifest"
+  echo "    openshift-installer needs to be updated"
+  echo "----------------------------------------------"
+  echo ""
+  return
+fi
+
+pullErr=$(grep "error pulling image" ${logb}/bootstrap/journals/release-image.log | wc -l)
+#echo "${pullErr} Pull Errors: from bootstrap/journals/release-image.log"
+grep "Error pulling image" ${logb}/bootstrap/journals/release-image.log | head -1
+if [[ ${pullErr} -ne 0 ]] ; then
+  echo "${pullErr} Pull Errors: from bootstrap/journals/release-image.log"
+  grep "error pulling image" ${logb}/bootstrap/journals/release-image.log | head -1
+else
+  echo "Pulled images"
+fi
+}
+
+# debugbootstrap
+bootkube () {
+echo "===================================================="
+echo "Check bootstrap/journals/bootkube.log"
+if [[ ! -f  ${logb}/bootstrap/journals/bootkube.log ]] ; then
+  echo "bootstrap/journals/bootkube.log file not found"
+  return
+fi
+
+grep "Error: unable to pull" ${logb}/bootstrap/journals/bootkube.log | head -1
+grep "container died" ${logb}/bootstrap/journals/bootkube.log | head -1
+grep "systemd" ${logb}/bootstrap/journals/bootkube.log | head -6
+grep -e " E0130 " ${logb}/bootstrap/journals/bootkube.log | head -4
+echo ""
+grep -e "Pod Status" ${logb}/bootstrap/journals/bootkube.log
+echo ""
+#echo "Checking for more errors"
+#grep -v -e "Error: unable to pull" -e "systemd" -e "podman"  ${logb}/bootstrap/journals/bootkube.log
+#grep -v -e " container " -e "Writing asset" -e " podman" -e " I0130 " \
+#	-e " E0130" -e ": Created " -e ": Skipped " -e ": Failed to create" \
+#	-e " failed to create " -e "Updated status" \
+#	-e "failed to fetch" -e "unable to get REST mapping" \
+#	${logb}/bootstrap/journals/bootkube.log
+#grep -v -e " create " -e " init " -e " start " -e " attach " -e " died " -e " remove "   ${logb}/bootstrap/journals/bootkube.log
+}
+
+# debugbootstrap
+crioConfig () {
+echo "===================================================="
+echo "Check bootstrap/journals/crio-configure.log"
+if [[ ! -f  ${logb}/bootstrap/journals/crio-configure.log ]] ; then
+  echo "bootstrap/journals/crio-configure.log file not found"
+  return
+fi
+
+#grep -e "container died" ${logb}/bootstrap/journals/crio-configure.log | head -1
+grep "systemd" ${logb}/bootstrap/journals/crio-configure.log | head -6
+}
+
+# debugbootstrap
+kubelet () {
+echo "===================================================="
+echo "Check bootstrap/journals/kubelet.log"
+if [[ ! -f  ${logb}/bootstrap/journals/kubelet.log ]] ; then
+  echo "bootstrap/journals/kubelet.log file not found"
+  return
+fi
+
+w=$(grep "CrashLoopBackOff" ${logb}/bootstrap/journals/kubelet.log | wc -l)
+echo "CrashLoopBackOff occurences: $w"
+e=$(grep "Error" ${logb}/bootstrap/journals/kubelet.log | wc -l)
+echo "Error occurences: $e"
+s=$(grep "status for pod" ${logb}/bootstrap/journals/kubelet.log | wc -l)
+echo "status for pod: $s"
+echo ""
+#grep -n -e "status for pod" -e "CrashLoopBackOff" -e "Error"  ${logb}/bootstrap/journals/kubelet.log
+}
+
+# debugbootstrap
+approveCsr () {
+echo "===================================================="
+echo "Check bootstrap/journals/approve-csr.log"
+if [[ ! -f  ${logb}/bootstrap/journals/approve-csr.log ]] ; then
+  echo "bootstrap/journals/approve-csr.log file not found"
+  return
+fi
+
+grep -n  -e "error" -e "was refused"  ${logb}/bootstrap/journals/approve-csr.log
+}
+
+pods() {
+echo "===================================================="
+echo "Check resources/pods.json"
+if [[ ! -f  ${logb}/resources/pods.json ]] ; then
+  echo "resources/pods.json file not found"
+  return
+fi
+
+echo "===================================================="
+echo "Looking for ovn/ovs pods"
+jq '.items[].metadata.name' ${logb}/resources/pods.json | grep -e ovn -e ovs
+
+echo "===================================================="
+jq '.items[].status.conditions[].message' ${logb}/resources/pods.json | grep "unready status"
+
+echo "===================================================="
+jq '.items[].status.conditions[].reason' ${logb}/resources/pods.json | grep -v null
+
+echo "===================================================="
+jq '.items[]' ${logb}/resources/pods.json | grep -e '"reason": "Error"' -e "CrashLoopBackOff"
+
+echo "===================================================="
+jq '.items[].status.containerStatuses' ${logb}/resources/pods.json | grep ovn -A2
+
+}
+
+masters-nodes () {
+echo "===================================================="
+echo "List all masters"
+if [[ ! -f  ${logb}/resources/masters.list ]] ; then
+  echo "resources/masters.list file not found"
+  return
+fi
+cat ${logb}/resources/masters.list
+
+echo "===================================================="
+echo "List all nodes"
+if [[ ! -f  ${logb}/resources/nodes.list ]] ; then
+  echo "resources/nodes.list file not found"
+  return
+fi
+cat ${logb}/resources/nodes.list
+
+echo "===================================================="
+echo "node networking -- resources/nodes.json"
+jq '.items[].status.conditions[3].message' ${logb}/resources/nodes.json
+}
+
+namespaces () {
+echo "===================================================="
+echo "Show ovn namespace -- resources/namespaces.json"
+if [[ ! -f  ${logb}/resources/namespaces.json ]] ; then
+  echo "resources/namespaces.json file not found"
+  return
+fi
+ns=$(jq '.items[].metadata.name' ${logb}/resources/namespaces.json | grep kubernetes)
+echo ${ns}
+if [[ ${ns} == "" ]] ; then
+  echo "----------------------------------------------"
+  echo " openhsift-ovn-kubernetes namespace missing"
+  echo "----------------------------------------------"
+  echo ""
+fi
+}
+
+clusteroperators () {
+echo "===================================================="
+echo "Show ovn in clusteroperators -- resources/clusteroperators.json"
+if [[ ! -f  ${logb}/resources/clusteroperators.json ]] ; then
+  echo "resources/clusteroperators.json file not found"
+  return
+fi
+jq '.items[].status.conditions[].message' ${logb}/resources/clusteroperators.json 
+}
+
+clusterversion () {
+echo "===================================================="
+echo "Show ovn in clusterversion -- resources/clusterversion.json"
+if [[ ! -f  ${logb}/resources/clusterversion.json ]] ; then
+  echo "resources/clusterversion.json file not found"
+  return
+fi
+jq '.items[].status.conditions[].message' ${logb}/resources/clusterversion.json 
+#echo ${ns}
+#if [[ ${ns} == "" ]] ; then
+  #echo "------------------------------------------------------"
+  #echo " openhsift-ovn-kubernetes missing in clusterversion"
+  #echo "------------------------------------------------------"
+  #echo ""
+#fi
+}
+
+configmaps () {
+echo "===================================================="
+echo "Show ovn namespace -- resources/configmaps.json"
+if [[ ! -f  ${logb}/resources/configmaps.json ]] ; then
+  echo "resources/configmaps.json file not found"
+  return
+fi
+ns=$(jq '.items[].metadata.namespace' ${logb}/resources/configmaps.json | grep kubernetes)
+echo ${ns}
+if [[ ${ns} == "" ]] ; then
+  echo "----------------------------------------------"
+  echo " openhsift-ovn-kubernetes namespace missing"
+  echo "----------------------------------------------"
+  echo ""
+fi
+}
+
+csr () {
+echo "===================================================="
+echo "Check certificates -- resources/csr.json"
+if [[ ! -f  ${logb}/resources/csr.json ]] ; then
+  echo "resources/csr.json file not found"
+  return
+fi
+jq '.items[].status.conditions[].message' ${logb}/resources/csr.json 
+}
+
+endpoints () {
+echo "===================================================="
+echo "Show endpoints -- resources/endpoints.json"
+if [[ ! -f  ${logb}/resources/endpoints.json ]] ; then
+  echo "resources/endpoints.json file not found"
+  return
+fi
+ep=$(jq '.items[].subsets' ${logb}/resources/endpoints.json | grep -e ovs -e ovn | grep -v namespace | gawk '{ print $2 }')
+for eep in ${ep} ; do
+  echo "  ${eep}"
+done
+if [[ ${ep} == "" ]] ; then
+  echo "----------------------------------------------"
+  echo " openhsift-ovn-kubernetes endpoints missing"
+  echo "----------------------------------------------"
+  echo ""
+fi
+}
+
+
+events () {
+echo "===================================================="
+echo "Show events -- resources/events.json"
+if [[ ! -f  ${logb}/resources/events.json ]] ; then
+  echo "resources/events.json file not found"
+  return
+fi
+ev=$(jq '.items[].involvedObject.namespace' ${logb}/resources/events.json | grep ovn-kubernetes)
+echo ${ev}
+if [[ ${ev} == "" ]] ; then
+  echo "----------------------------------------------"
+  echo " openhsift-ovn-kubernetes events missing"
+  echo "----------------------------------------------"
+  echo ""
+fi
+}
+
+rolebindings () {
+echo "===================================================="
+echo "Check certificates -- resources/rolebindings.json"
+if [[ ! -f  ${logb}/resources/rolebindings.json ]] ; then
+  echo "resources/rolebindings.json file not found"
+  return
+fi
+ev=$(jq '.items[].metadata.name' ${logb}/resources/rolebindings.json | grep ovn)
+echo ${ev}
+if [[ ${ev} == "" ]] ; then
+  echo "---------------------------------------------------"
+  echo " openhsift-ovn-kubernetes-sbdb rolebinding missing"
+  echo "---------------------------------------------------"
+  echo ""
+fi
+}
+
+roles () {
+echo "===================================================="
+echo "Check certificates -- resources/roles.json"
+if [[ ! -f  ${logb}/resources/roles.json ]] ; then
+  echo "resources/roles.json file not found"
+  return
+fi
+ev=$(jq '.items[].metadata.name' ${logb}/resources/roles.json | grep ovn)
+echo ${ev}
+if [[ ${ev} == "" ]] ; then
+  echo "---------------------------------------------------"
+  echo " openhsift-ovn-kubernetes-sbdb role missing"
+  echo "---------------------------------------------------"
+  echo ""
+fi
+}
+
+services () {
+echo "===================================================="
+echo "Check certificates -- resources/services.json"
+if [[ ! -f  ${logb}/resources/services.json ]] ; then
+  echo "resources/services.json file not found"
+  return
+fi
+ev=$(jq '.items[].metadata.name' ${logb}/resources/services.json | grep ovn)
+echo ${ev}
+if [[ ${ev} == "" ]] ; then
+  echo "---------------------------------------------------"
+  echo " ovn services missing"
+  echo "---------------------------------------------------"
+  echo ""
+fi
+}
+
+
+#-------------------------------------
+logs () {
+#echo "===================================================="
+#echo "List all log files"
+#find ${logb} -name \*log
+
+echo "===================================================="
+echo "CNO - Look for bad networktype"
+grep -r -w -e "NOTICE: Unknown network type" ${logb}/control-plane/*/containers/*.log 2>/dev/null
+
+echo "===================================================="
+echo "Look for container Errors"
+grep -r -w -e Error ${logb}/control-plane/*/containers/*.log 2>/dev/null | head -4
+
+echo "===================================================="
+echo "Look for fatal msg"
+grep -r -w -e "fatal msg" ${logb}/control-plane/*/containers/*.log 2>/dev/null | head -4
+
+echo "===================================================="
+echo "Look for E1125"
+logs=$(find MY-CLUSTER-OVN-2/log-bundle-20191125152251/ -name *.log 2>/dev/null)
+for i in $logs ; do echo $i ; grep E1125 $i | head -3 ; done
+#grep -r -w -e "E1125" ${logb}/control-plane/*/containers/*.log | head -4
+
+echo "===================================================="
+echo "Look for panic"
+if [[ -f  ${logb}/bootstrap/containers/bootstrap-control-plane/kube-apiserver.log ]] ; then
+  grep -r -w -e panic ${logb}/bootstrap/containers/bootstrap-control-plane/kube-apiserver.log | head -4
+
+echo "===================================================="
+echo "Observed a panic"
+  find ${logb} -name \*.log | xargs grep "Observed a panic" | tail -4
+fi
+
+echo "===================================================="
+echo "Look for timeouts"
+grep -r "Timeout error while obtaining addresses" ${logb}
+
+echo "===================================================="
+echo "Look for Error while obtaining gateway"
+grep -r "Error while obtaining gateway" ${logb} | head -3
+
+echo "===================================================="
+echo "Look for failed to get aggregate flow statistics"
+grep -r "failed to get aggregate flow statistics" ${logb} | head -3
+
+echo "===================================================="
+echo "Look for election results"
+grep -r -w -e "election" ${logb}/control-plane/*/containers/ovn*.log 2>/dev/null | head -4
+
+
+}
+
+
+# get the logs from the cluster
+if [[ ${2:-XX} == "gather" ]] ; then
+  gather
+else
+  # use a previously gathered log-bundle
+  if [[ -d ${1}/${2:-XX} ]] ; then
+	logb=${1}/${2}
+  else
+	logb=$(ls ${1}/log-bundle-*.tar.gz | sed 's/.tar.gz//')
+  fi
+fi
+echo logb $logb
+
+echo "===================================================="
+echo "===================================================="
+echo "bootstrap/journals"
+releaseImage
+bootkube
+crioConfig
+approveCsr
+kubelet
+echo "===================================================="
+echo "resources"
+namespaces
+clusteroperators
+clusterversion
+configmaps
+csr
+endpoints
+events
+masters-nodes
+pods
+rolebindings
+roles
+services
+echo "===================================================="
+echo "logs"
+logs
+
+exit 0
+
+
+

--- a/ocp/notes
+++ b/ocp/notes
@@ -1,0 +1,55 @@
+/home/pcameron/Desktop/trace-ovn/ovn/https:/gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/pr-logs/pull/openshift_ovn-kubernetes/194/pull-ci-openshift-ovn-kubernetes-master-e2e-gcp-ovn/1275048833591545856/artifacts/e2e-gcp-ovn
+
+$ jq '.items[223,224].metadata.name,.items[223,224].spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].values[0]' pods.json 
+"ovs-node-9s7h4"
+"ovs-node-crlng"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-d-89sfx"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-b-qsx2f"
+
+$ jq '.items[214,228].metadata.name' pods.json 
+"ovnkube-master-8g2mt"
+"ovs-node-w748j"
+
+$ jq '.items[214,215,216,217,218,219,220,221,222,223,224,225,226,227,228].metadata.name,.items[214,215,216,217,218,219,220,221,222,223,224,225,226,227,228].spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].values[0]' pods.json 
+"ovnkube-master-8g2mt"
+"ovnkube-master-dlnn6"
+"ovnkube-master-xst4d"
+"ovnkube-node-bg8gp"
+"ovnkube-node-kkv88"
+"ovnkube-node-m2tcj"
+"ovnkube-node-rpf5n"
+"ovnkube-node-rxnnq"
+"ovnkube-node-sbzmv"
+"ovs-node-9s7h4"
+"ovs-node-crlng"
+"ovs-node-qhbhn"
+"ovs-node-rqcz4"
+"ovs-node-v7fqr"
+"ovs-node-w748j"
+"ci-op-ns0pyr56-99b10-ww6mq-master-1"
+"ci-op-ns0pyr56-99b10-ww6mq-master-2"
+"ci-op-ns0pyr56-99b10-ww6mq-master-0"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-b-qsx2f"
+"ci-op-ns0pyr56-99b10-ww6mq-master-2"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-d-89sfx"
+"ci-op-ns0pyr56-99b10-ww6mq-master-1"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-c-bbrwk"
+"ci-op-ns0pyr56-99b10-ww6mq-master-0"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-d-89sfx"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-b-qsx2f"
+"ci-op-ns0pyr56-99b10-ww6mq-worker-c-bbrwk"
+"ci-op-ns0pyr56-99b10-ww6mq-master-2"
+"ci-op-ns0pyr56-99b10-ww6mq-master-0"
+"ci-op-ns0pyr56-99b10-ww6mq-master-1"
+
+
+
+------------------
+find . -name \*-journal
+grep -e "crio\[" -e "SyncLoop" ./nodes/masters-journal ./nodes/workers-journal
+
+kubelet.go pod_workers.go hyperkube
+event.go
+NetworkNotReady Has your network provider started
+grep  -e "hyperkube" -e "crio\["  nodes/*-journal 
+

--- a/ocp/ovn-trace
+++ b/ocp/ovn-trace
@@ -1,0 +1,169 @@
+#!/bin/bash
+#set -x
+# cd to directory with extracted artifacts
+# OUT is the directory to put results
+# OUT=my-trace ./ovn_trace
+# ls my-trace
+
+out=${OUT:-trace_out}
+
+# Convert the date and add the prefix
+function convert_log_timestamp {
+  grep -e "^I" -e "^E" -e "^W" -e "^N" | \
+    sed 's/ /-/;s/^[IEWDN]/& /' | \
+    gawk '{ print $2  " | "  $0; }' | \
+    sed "s/|/ ${1} ${2} ${3} | /" | \
+    sed '/^[+a-zA-Z/]/d'
+}
+
+function convert_ovs_timestamp {
+  sed 's/2020-//;s/-//;s/T/-/;s/Z//' | \
+    sed "s/|/ ${1} ${2} ${3} | /" | \
+    sed '/^[+a-zA-Z/]/d'
+}
+
+function convert_journal_timestamp {
+  sed 's/Jan /01/; s/Feb /02/; s/Mar /03/; s/Apr /04/; s/May /05/; s/Jun /06/;
+    s/Jul /07/; s/Aug /08/; s/Sep /09/; s/Oct /10/; s/Nov /11/; s/Dec /12/;
+    s/ /-/' | sed '/^---/d'
+}
+
+function processLogs {
+  logs=$(find . -type f -name \*.log | grep -e "openshift-ovn-kubernetes_")
+  pods=$(find . -name pods.json | grep -v build-resources)
+  pds=$(jq '.items[].metadata.name' ${pods})
+
+  for log in ${logs} ; do
+    pdCn=$(basename $log | sed 's/_/ /g;s/\./ /g' | gawk '{ print $2 " " $3}')
+    pod=$(echo ${pdCn} | gawk '{ print $1 }')
+    con=$(echo ${pdCn} | gawk '{ print $2 }')
+    podd=\"$pod\"
+#   basename $log
+#   echo "    pod: $pod container: $con"
+
+    ind=0
+    for pd in ${pds} ; do
+      if [[ ${pd} == ${podd} ]] ; then
+        node=$(jq ".items[${ind}].spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].values[0]" ${pods} | sed 's/"//g')
+        basename $log
+        echo "    $node --- $pod --- $con"
+        if [[ ${con} == "ovnkube-master" || ${con} == "ovnkube-node" ]] ; then
+          cat ${log} | convert_log_timestamp "${node}" "${pod}" "${con}" >> ${out}/trace.log
+        else
+          cat ${log} | convert_ovs_timestamp "${node}" "${pod}" "${con}" >> ${out}/trace.log
+        fi
+      fi
+
+      ind=$((ind+1))
+    done
+  done
+}
+
+function processJournals {
+  journals=$(find . -name \*-journal)
+  for journal in ${journals} ; do
+    echo ${journal}
+    grep  -e "crio\[" ${journal} | convert_journal_timestamp >> ${out}/trace.log
+    grep  -e "hyperkube" ${journal} | grep -e "\]: E" -e "SyncLoop" | convert_journal_timestamp >> ${out}/trace.log
+  done
+}
+
+# generate a trace of key parts of ovn startup
+function ovn_generate_startup_trace {
+  outS=${out}/startup.log
+  rm -f ${outS}
+  rm -f ${out}/ovn_startup_trace ${out}/ovn_startup_ready
+  touch ${outS}
+
+  # The trace records node-start, container start, election results, container ready
+  gawk '/Starting MCO environment/{ print $1 " " $2 "  Starting MCO environment on node"}' ${tf} >> ${outS}
+  echo " "
+
+  # Find first line in each ovn container and assume its the start.
+  grep -e "00001|vlog|INFO|opened log file" -e "ovn-controller | 00001|" -e "northd | 00001|reconnect" -e "Parsed config file" ${tf} \
+     | gawk '{ print $1 " " $2 " " $3 " " $4 "  Container starting" }' >> ${outS}
+
+  # container is "ready" when it transitions to handling requests
+  # sometimes we can tell, other times we assume we know.
+  # ovs is ready when br_int is set
+  grep -e "bridge br-int: added interface br-int on port" ${tf} | gawk '{ print $1 " " $2 " " $3 " " $4 "  OVS Ready" }' >> ${outS}
+  # ovn-controller ready
+  grep 'rconn|INFO|unix:/var/run/openvswitch/br-int.mgmt: connected' ${tf} | gawk '{ print $1 " " $2 " " $3 " " $4 "  Ready" }' >> ${outS}
+  # nbdb and sbdb - assumed ready after "peak resident set size after 10.0"
+  grep "peak resident set size after 10.0" ${tf} | grep " nbdb " |gawk '{ print $1 " " $2 " " $3 " " $4 "  nbdb Ready" }' >> ${outS}
+  grep "peak resident set size after 10.0" ${tf} | grep " sbdb " |gawk '{ print $1 " " $2 " " $3 " " $4 "  sbdb Ready" }' >> ${outS}
+  # ovnkube-master, ovnkube-node are ready when start watching config.
+  grep "Watching config file /run/ovnkube-config/ovnkube.conf" ${tf} | gawk '{ print $1 " " $2 " " $3 " " $4 "  Ready" }' >> ${outS}
+
+  # find the containers that won the election
+  # ovnkube-master
+  grep -e "won leader election" ${tf} | gawk '{ print $1 " " $2 " " $3 " " $4 "  ACTIVE" }' >> ${outS}
+  # nbdb and sbdb - the container that starts the election wins
+  grep -e "starting election" ${tf} | gawk '{ print $1 " " $2 " " $3 " " $4 "  ACTIVE" }' >> ${outS}
+  # northd - the active container does "Assigned dynamic"
+  grep -e "ovn_northd|INFO|Assigned dynamic" ${tf} | head -1 | gawk '{ print $1 " " $2 " " $3 " " $4 "  ACTIVE" }' >> ${outS}
+
+  sort ${outS} > ${out}/ovn_startup_trace
+  # don't delete, needed in ovn_show_errors
+  #rm -f ${outS}
+
+  # get all container sin Ready state
+  echo "ovn containers in ready state" > ${out}/ovn_startup_ready
+  grep "Ready" ${out}/ovn_startup_trace | gawk '{ print$2 " " $3 " " $4 " " $5 " " $6 }' | sort >> ${out}/ovn_startup_ready
+
+}
+
+# [WIP] trying to tease out any errors
+function ovn_show_errors {
+  # startup.log from ovn_generate_startup_trace
+  outS=${out}/startup.log
+  outE=${out}/error.log
+  cp ${outS} ${outE}
+  rm -f ${out}/ovn_error_trace
+
+  # look for common errors
+  grep -e "No CNI configuration file" ${tf} | gawk '{ print $1 " " $2 " " $3 "  ERROR- No CNI configuration file -ERROR" }' >> ${outE}
+  grep -e "Failed to initialize CSINode" ${tf} | gawk '{ print $1 " " $2 " " $3 "  ERROR- Failed to initialize CSINode -ERROR" }' >> ${outE}
+
+  sort ${outE} > ${out}/ovn_error_trace
+  rm -f ${outE}
+}
+
+function ovn_generate_trace {
+  rm -rf ${out}
+  mkdir -p ${out}
+  touch ${out}/trace.log
+  rm -f ${tf}
+
+  processLogs
+  processJournals
+
+  sort ${out}/trace.log > ${tf}
+  rm ${out}/trace.log
+}
+
+function setup {
+  pf=$(find . -name pods.json | grep -v build-resources)
+  if [[ $? -ne 0 ]] ; then
+    echo "collected artifacts doesn't contain a pods.json file"
+    exit 1
+  fi
+  jq '.items[].metadata.namespace' ${pf} | grep openshift-ovn-kubernetes > /dev/null 2>&1
+  if [[ $? -ne 0 ]] ; then
+    echo "collected artifacts are not for an openshift-ovn-kubernetes cluster"
+    exit 2
+  fi
+}
+
+# --------------
+# output trace file
+tf=${out}/ovn_trace
+
+# quick check to verify the artifacts are from an openshift-ovn-kubernetes cluster
+setup 
+
+ovn_generate_trace
+
+ovn_generate_startup_trace
+
+ovn_show_errors


### PR DESCRIPTION
ovn-trace
OUT=output-dir ovn-trace

Trace is done in current directory which must contain previously
downloaded CI artifacts. Output trace is in trace_out or content of OUT.

The *-journal and openshift-ovn-namespace log files are processed.
The hyperkube SyncLoop and errors and crio are extracted from the
journals.
The whole current and previous logs are processed.

Each log line get a common prefix that consists of
- timestamp in common format
- node name
- pod name
- container name

The remainder of the line is not changed.

All of the lines are sorted into a time sequence trace.
The trace is analyzed for ovn container bringup and reported in another
file.

This is useful for analyzing ci test failures until the must-gather
version is available. Its also a basis for additional experimenting.

Signed-off-by: Phil Cameron <pcameron@redhat.com>